### PR TITLE
Feature/#13 epsilon update

### DIFF
--- a/src/rank_bandit_lab/policies.py
+++ b/src/rank_bandit_lab/policies.py
@@ -88,9 +88,13 @@ class EpsilonGreedyRanking(RankingPolicy):
         for doc_id in interaction.seen:
             stats = self._stats[doc_id]
             stats.impressions += 1
-        clicked_doc = interaction.clicked_doc_id
-        if clicked_doc is not None:
-            self._stats[clicked_doc].clicks += 1
+        clicked_docs = interaction.clicked_doc_ids
+        if not clicked_docs:
+            clicked_doc = interaction.clicked_doc_id
+            if clicked_doc is not None:
+                clicked_docs = (clicked_doc,)
+        for doc_id in clicked_docs:
+            self._stats[doc_id].clicks += 1
 
     def _score(self, doc_id: str) -> float:
         stats = self._stats[doc_id]

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -30,6 +30,25 @@ class PolicyTests(unittest.TestCase):
         self.assertEqual(slate[0], "a")
         self.assertEqual(len(slate), 2)
 
+    def test_epsilon_greedy_counts_all_clicked_docs(self) -> None:
+        policy = EpsilonGreedyRanking(
+            doc_ids=["a", "b", "c"],
+            slate_size=3,
+            epsilon=0.0,
+            rng=Random(1),
+        )
+        interaction = Interaction(
+            slate=("a", "b", "c"),
+            seen=("a", "b", "c"),
+            click_index=0,
+            reward=2.0,
+            click_positions=(0, 2),
+        )
+        policy.update(interaction)
+        self.assertEqual(policy._stats["a"].clicks, 1)  # type: ignore[attr-defined]
+        self.assertEqual(policy._stats["c"].clicks, 1)  # type: ignore[attr-defined]
+        self.assertEqual(policy._stats["b"].clicks, 0)  # type: ignore[attr-defined]
+
     def test_thompson_sampling_tracks_successes_and_failures(self) -> None:
         policy = ThompsonSamplingRanking(
             doc_ids=["a", "b"],


### PR DESCRIPTION
EpsilonGreedy が複数クリックのうち先頭 1 件しか学習しない問題 (#13) を修正し、Interaction.clicked_doc_ids すべてにクリックを加算するようにしました。
PBM/DCM の複数クリックケースをカバーする回帰テスト test_epsilon_greedy_counts_all_clicked_docs を追加しました。